### PR TITLE
Performance improvements

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,5 +3,6 @@
     "test": "deno test src",
     "bench": "deno bench --unstable src",
     "npm": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run scripts/build_npm.ts"
-  }
+  },
+  "lock": false
 }

--- a/scripts/measure_respond.ts
+++ b/scripts/measure_respond.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "https://deno.land/std@0.158.0/testing/asserts.ts";
+import { FingerprintTree } from "../src/fingerprint_tree/fingerprint_tree.ts";
+import { concatMonoid } from "../src/lifting_monoid.ts";
+import { RangeMessenger } from "../src/range_messenger/range_messenger.ts";
+import { objConfig } from "../src/range_messenger/range_messenger_config.ts";
+import { reconcile } from "../src/util.ts";
+
+function makeSet(size: number): number[] {
+  const set = new Set<number>();
+
+  for (let i = 0; i < size; i++) {
+    const int = Math.floor(Math.random() * ((size * 2) - 1 + 1) + 1);
+
+    set.add(int);
+  }
+
+  return Array.from(set);
+}
+
+function compare<T>(a: T, b: T) {
+  if (a > b) {
+    return 1;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+function nativeEquals(a: string, b: string) {
+  return a === b;
+}
+
+const setSize = 10000;
+
+const treeA = new FingerprintTree(concatMonoid, compare);
+
+const setA = makeSet(setSize);
+
+for (const item of setA) {
+  treeA.insert(`${item}`);
+}
+
+const brokerA = new RangeMessenger({
+  tree: treeA,
+  fingerprintEquals: nativeEquals,
+  encoding: objConfig,
+  payloadThreshold: 1,
+  rangeDivision: 2,
+});
+
+// Other peer
+
+const treeB = new FingerprintTree(concatMonoid, compare);
+
+const setB = makeSet(setSize);
+
+for (const item of setB) {
+  treeB.insert(`${item}`);
+}
+
+const brokerB = new RangeMessenger({
+  tree: treeB,
+  fingerprintEquals: nativeEquals,
+  encoding: objConfig,
+  payloadThreshold: 1,
+  rangeDivision: 2,
+});
+
+await reconcile(brokerA, brokerB);
+
+assertEquals(treeA.lnrValues(), treeB.lnrValues());

--- a/src/fingerprint_tree/fingerprint_tree.bench.ts
+++ b/src/fingerprint_tree/fingerprint_tree.bench.ts
@@ -40,7 +40,7 @@ for (const vec of vectors) {
     } else {
       return 0;
     }
-  }, "" as string);
+  });
 
   const rbTree = new RedBlackTree();
 

--- a/src/fingerprint_tree/fingerprint_tree.bench.ts
+++ b/src/fingerprint_tree/fingerprint_tree.bench.ts
@@ -16,14 +16,14 @@ function makeSet(size: number): number[] {
 
 type BenchVector = [
   number,
-  { min: string; fstqrt: string; mid: string; thdqrt: string },
+  { fstqrt: string; mid: string; thdqrt: string },
 ];
 
 const vectors: BenchVector[] = [
-  [10, { min: "1", fstqrt: "2", mid: "5", thdqrt: "7" }],
-  [100, { min: "0", fstqrt: "25", mid: "50", thdqrt: "75" }],
-  [1000, { min: "0", fstqrt: "250", mid: "500", thdqrt: "750" }],
-  [10000, { min: "0", fstqrt: "2500", mid: "5000", thdqrt: "7500" }],
+  [10, { fstqrt: "2", mid: "5", thdqrt: "7" }],
+  [100, { fstqrt: "25", mid: "50", thdqrt: "75" }],
+  [1000, { fstqrt: "250", mid: "500", thdqrt: "750" }],
+  [10000, { fstqrt: "2500", mid: "5000", thdqrt: "7500" }],
 ];
 
 for (const vec of vectors) {
@@ -65,7 +65,9 @@ for (const vec of vectors) {
     group: `fingerprint (${vec})`,
     baseline: true,
   }, () => {
-    tree.getFingerprint(boundaries.min, boundaries.min);
+    const min = tree.getLowestValue();
+
+    tree.getFingerprint(min, min);
   });
 
   Deno.bench(`Fingerprint mid - mid (${size} items) `, {
@@ -77,13 +79,15 @@ for (const vec of vectors) {
   Deno.bench(`Fingerprint min - mid (${size} items) `, {
     group: `fingerprint (${vec})`,
   }, () => {
-    tree.getFingerprint(boundaries.min, boundaries.mid);
+    const min = tree.getLowestValue();
+    tree.getFingerprint(min, boundaries.mid);
   });
 
   Deno.bench(`Fingerprint mid - min (${size} items) `, {
     group: `fingerprint (${vec})`,
   }, () => {
-    tree.getFingerprint(boundaries.mid, boundaries.min);
+    const min = tree.getLowestValue();
+    tree.getFingerprint(boundaries.mid, min);
   });
 
   Deno.bench(`Fingerprint fstqrt - thdqrt (${size} items) `, {

--- a/src/fingerprint_tree/fingerprint_tree.bench.ts
+++ b/src/fingerprint_tree/fingerprint_tree.bench.ts
@@ -14,9 +14,22 @@ function makeSet(size: number): number[] {
   return Array.from(set);
 }
 
-const sizes = [1, 10, 100, 1000, 10000];
+type BenchVector = [
+  number,
+  { min: string; fstqrt: string; mid: string; thdqrt: string },
+];
 
-for (const size of sizes) {
+const vectors: BenchVector[] = [
+  [10, { min: "1", fstqrt: "2", mid: "5", thdqrt: "7" }],
+  [100, { min: "0", fstqrt: "25", mid: "50", thdqrt: "75" }],
+  [1000, { min: "0", fstqrt: "250", mid: "500", thdqrt: "750" }],
+  [10000, { min: "0", fstqrt: "2500", mid: "5000", thdqrt: "7500" }],
+];
+
+for (const vec of vectors) {
+  const size = vec[0];
+  const boundaries = vec[1];
+
   const set = makeSet(size);
 
   const tree = new FingerprintTree(concatMonoid, (a, b) => {
@@ -28,10 +41,11 @@ for (const size of sizes) {
       return 0;
     }
   }, "" as string);
+
   const rbTree = new RedBlackTree();
 
   Deno.bench(`Insert into RedBlackTree (${size} items)`, {
-    group: `insert (${size})`,
+    group: `insert (${vec})`,
     baseline: true,
   }, () => {
     for (const element of set) {
@@ -40,38 +54,47 @@ for (const size of sizes) {
   });
 
   Deno.bench(`Insert into FingerPrintTree (${size} items)`, {
-    group: `insert (${size})`,
+    group: `insert (${vec})`,
   }, () => {
     for (const element of set) {
       tree.insert(`${element}`);
     }
   });
 
-  const min = `${Math.min(...set)}`;
-  const mid = `${Math.floor(Math.max(...set) / 2)}`;
-
   Deno.bench(`Fingerprint min - min (${size} items) `, {
-    group: `fingerprint (${size})`,
+    group: `fingerprint (${vec})`,
     baseline: true,
   }, () => {
-    tree.getFingerprint(min, min);
-  });
-
-  Deno.bench(`Fingerprint min - mid (${size} items) `, {
-    group: `fingerprint (${size})`,
-  }, () => {
-    tree.getFingerprint(min, mid);
+    tree.getFingerprint(boundaries.min, boundaries.min);
   });
 
   Deno.bench(`Fingerprint mid - mid (${size} items) `, {
-    group: `fingerprint (${size})`,
+    group: `fingerprint (${vec})`,
   }, () => {
-    tree.getFingerprint(mid, mid);
+    tree.getFingerprint(boundaries.mid, boundaries.mid);
+  });
+
+  Deno.bench(`Fingerprint min - mid (${size} items) `, {
+    group: `fingerprint (${vec})`,
+  }, () => {
+    tree.getFingerprint(boundaries.min, boundaries.mid);
   });
 
   Deno.bench(`Fingerprint mid - min (${size} items) `, {
-    group: `fingerprint (${size})`,
+    group: `fingerprint (${vec})`,
   }, () => {
-    tree.getFingerprint(mid, min);
+    tree.getFingerprint(boundaries.mid, boundaries.min);
+  });
+
+  Deno.bench(`Fingerprint fstqrt - thdqrt (${size} items) `, {
+    group: `fingerprint (${vec})`,
+  }, () => {
+    tree.getFingerprint(boundaries.fstqrt, boundaries.thdqrt);
+  });
+
+  Deno.bench(`Fingerprint thrqrt - fstqrt (${size} items) `, {
+    group: `fingerprint (${vec})`,
+  }, () => {
+    tree.getFingerprint(boundaries.thdqrt, boundaries.fstqrt);
   });
 }

--- a/src/fingerprint_tree/fingerprint_tree.bench.ts
+++ b/src/fingerprint_tree/fingerprint_tree.bench.ts
@@ -27,7 +27,7 @@ for (const size of sizes) {
     } else {
       return 0;
     }
-  });
+  }, "" as string);
   const rbTree = new RedBlackTree();
 
   Deno.bench(`Insert into RedBlackTree (${size} items)`, {

--- a/src/fingerprint_tree/fingerprint_tree.test.ts
+++ b/src/fingerprint_tree/fingerprint_tree.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.158.0/testing/asserts.ts";
 import { concatMonoid } from "../lifting_monoid.ts";
 import { FingerprintTree } from "./fingerprint_tree.ts";
 
-// The range, the fingerprint, size, and collected items.
+// The range, the fingerprint, size, collected items.
 type RangeVector = [[string, string], string, number, string[]];
 
 const rangeVectors: RangeVector[] = [
@@ -32,6 +32,7 @@ Deno.test("FingerprintTree", () => {
         return 0;
       }
     },
+    "" as string,
   );
 
   const set = ["a", "b", "c", "d", "e", "f", "g"];

--- a/src/fingerprint_tree/fingerprint_tree.test.ts
+++ b/src/fingerprint_tree/fingerprint_tree.test.ts
@@ -32,7 +32,6 @@ Deno.test("FingerprintTree", () => {
         return 0;
       }
     },
-    "" as string,
   );
 
   const set = ["a", "b", "c", "d", "e", "f", "g"];

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -386,7 +386,11 @@ export class FingerprintTree<ValueType, LiftedType>
         nextTree: null,
       };
     } else if (order < 0) {
-      const nodeToPass = nextTree || this.findGteNode(
+      const minNode = this.compare(x, this.cachedMinNode!.value) <= 0
+        ? this.cachedMinNode
+        : null;
+
+      const nodeToPass = nextTree || minNode || this.findGteNode(
         x,
       ) as NodeType<ValueType, LiftedType>;
 
@@ -464,7 +468,11 @@ export class FingerprintTree<ValueType, LiftedType>
           nextTree: nextTree,
         };
       } else {
-        const nodeToPass = nextTree || this.findGteNode(
+        const minNode = this.compare(x, this.cachedMinNode!.value) <= 0
+          ? this.cachedMinNode
+          : null;
+
+        const nodeToPass = nextTree || minNode || this.findGteNode(
           x,
         ) as NodeType<ValueType, LiftedType>;
 

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -143,6 +143,10 @@ export class FingerprintTree<ValueType, LiftedType>
       throw new Error("Can't get a range from a tree with no items");
     }
 
+    if (this.cachedMinNode) {
+      return this.cachedMinNode.value;
+    }
+
     return this.root.findMinNode().value;
   }
 
@@ -383,7 +387,7 @@ export class FingerprintTree<ValueType, LiftedType>
         fingerprint: this.root.label[0],
         size: this.root.label[1][0],
         items: this.root.label[1][1][0],
-        nextTree: null,
+        nextTree: this.cachedMinNode,
       };
     } else if (order < 0) {
       const minNode = this.compare(x, this.cachedMinNode!.value) <= 0

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -105,17 +105,31 @@ export class FingerprintTree<ValueType, LiftedType>
     monoid: LiftingMonoid<ValueType, LiftedType>,
     /** A function to sort values by. Will use JavaScript's default comparison if not provided. */
     compare: (a: ValueType, b: ValueType) => number,
-    lowestValue: ValueType,
   ) {
     super(compare);
 
     const maxMonoid = {
       lift: (v: ValueType) => v,
-      combine: (a: ValueType, b: ValueType) => {
+      combine: (
+        a: ValueType | undefined,
+        b: ValueType | undefined,
+      ): ValueType => {
+        if (a === undefined && b === undefined) {
+          return undefined as never;
+        }
+
+        if (b === undefined) {
+          return a as ValueType;
+        }
+
+        if (a === undefined) {
+          return b;
+        }
+
         return compare(a, b) > 0 ? a : b;
       },
-      neutral: lowestValue,
-    };
+      neutral: undefined,
+    } as LiftingMonoid<ValueType, ValueType>;
 
     /** A monoid which lifts the member into an array, and combines by concatenating together. */
     const collectorMonoid = {

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -47,10 +47,10 @@ export class FingerprintNode<
       );
     } else if (this.left && this.right) {
       this.label = this.monoid.combine(
-        this.left?.label || this.monoid.neutral,
+        this.left.label,
         this.monoid.combine(
           this.liftedValue,
-          this.right?.label || this.monoid.neutral,
+          this.right.label,
         ),
       );
     } else {
@@ -177,7 +177,9 @@ export class FingerprintTree<ValueType, LiftedType>
       );
     }
 
-    if (debug) console.group("Rotating", direction);
+    if (debug) {
+      console.group("Rotating", direction);
+    }
 
     const replacement: NodeType<ValueType, LiftedType> =
       node[replacementDirection]!;
@@ -212,7 +214,9 @@ export class FingerprintTree<ValueType, LiftedType>
 
     replacement[direction]?.updateLabel(false, "Node rotated");
 
-    console.groupEnd();
+    if (debug) {
+      console.groupEnd();
+    }
   }
 
   removeFixup(

--- a/src/lifting_monoid.ts
+++ b/src/lifting_monoid.ts
@@ -1,3 +1,5 @@
+import { FingerprintNode } from "./fingerprint_tree/fingerprint_tree.ts";
+
 export type LiftingMonoid<ValueType, LiftedType> = {
   lift: (i: ValueType) => LiftedType;
   combine: (
@@ -44,3 +46,17 @@ export const sizeMonoid: LiftingMonoid<unknown, number> = {
   combine: (a: number, b: number) => a + b,
   neutral: 0,
 };
+
+/** A higher-order monoid which is able to determine the maximum value of a node. */
+export function makeMaxChildMonoid<ValueType>(
+  compare: (a: ValueType, b: ValueType) => number,
+  lowestValue: ValueType,
+): LiftingMonoid<ValueType, ValueType> {
+  return {
+    lift: (v) => v,
+    combine: (a: ValueType, b: ValueType) => {
+      return compare(a, b) > 0 ? a : b;
+    },
+    neutral: lowestValue,
+  };
+}

--- a/src/lifting_monoid.ts
+++ b/src/lifting_monoid.ts
@@ -46,17 +46,3 @@ export const sizeMonoid: LiftingMonoid<unknown, number> = {
   combine: (a: number, b: number) => a + b,
   neutral: 0,
 };
-
-/** A higher-order monoid which is able to determine the maximum value of a node. */
-export function makeMaxChildMonoid<ValueType>(
-  compare: (a: ValueType, b: ValueType) => number,
-  lowestValue: ValueType,
-): LiftingMonoid<ValueType, ValueType> {
-  return {
-    lift: (v) => v,
-    combine: (a: ValueType, b: ValueType) => {
-      return compare(a, b) > 0 ? a : b;
-    },
-    neutral: lowestValue,
-  };
-}

--- a/src/range_messenger/range_messenger.bench.ts
+++ b/src/range_messenger/range_messenger.bench.ts
@@ -37,13 +37,13 @@ for (const size of sizes) {
   const setB = makeSet(size);
 
   Deno.bench(`Instantiate two sets (size ${size})`, () => {
-    const treeA = new FingerprintTree(concatMonoid, compare);
+    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
 
     for (const item of setA) {
       treeA.insert(`${item}`);
     }
 
-    const treeB = new FingerprintTree(concatMonoid, compare);
+    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
 
     for (const item of setB) {
       treeB.insert(`${item}`);
@@ -51,13 +51,13 @@ for (const size of sizes) {
   });
 
   Deno.bench(`Instantiate and sync two sets (size ${size})`, async () => {
-    const treeA = new FingerprintTree(concatMonoid, compare);
+    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
 
     for (const item of setA) {
       treeA.insert(`${item}`);
     }
 
-    const treeB = new FingerprintTree(concatMonoid, compare);
+    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
 
     for (const item of setB) {
       treeB.insert(`${item}`);

--- a/src/range_messenger/range_messenger.bench.ts
+++ b/src/range_messenger/range_messenger.bench.ts
@@ -37,13 +37,13 @@ for (const size of sizes) {
   const setB = makeSet(size);
 
   Deno.bench(`Instantiate two sets (size ${size})`, () => {
-    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeA = new FingerprintTree(concatMonoid, compare);
 
     for (const item of setA) {
       treeA.insert(`${item}`);
     }
 
-    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeB = new FingerprintTree(concatMonoid, compare);
 
     for (const item of setB) {
       treeB.insert(`${item}`);
@@ -51,13 +51,13 @@ for (const size of sizes) {
   });
 
   Deno.bench(`Instantiate and sync two sets (size ${size})`, async () => {
-    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeA = new FingerprintTree(concatMonoid, compare);
 
     for (const item of setA) {
       treeA.insert(`${item}`);
     }
 
-    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeB = new FingerprintTree(concatMonoid, compare);
 
     for (const item of setB) {
       treeB.insert(`${item}`);

--- a/src/range_messenger/range_messenger.bench.ts
+++ b/src/range_messenger/range_messenger.bench.ts
@@ -2,7 +2,7 @@ import { FingerprintTree } from "../fingerprint_tree/fingerprint_tree.ts";
 import { concatMonoid } from "../lifting_monoid.ts";
 import { RangeMessenger } from "./range_messenger.ts";
 import { objConfig } from "./range_messenger_config.ts";
-import { sync } from "../util.ts";
+import { reconcile } from "../util.ts";
 
 function makeSet(size: number): number[] {
   const set = new Set<number>();
@@ -82,6 +82,6 @@ for (const size of sizes) {
       },
     );
 
-    await sync(messengerA, messengerB);
+    await reconcile(messengerA, messengerB);
   });
 }

--- a/src/range_messenger/range_messenger.test.ts
+++ b/src/range_messenger/range_messenger.test.ts
@@ -55,7 +55,7 @@ function nativeEquals(a: string, b: string) {
 }
 
 async function createTestCase() {
-  const treeA = new FingerprintTree(concatMonoid, compare);
+  const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
 
   const setA = createTestSet();
 
@@ -73,7 +73,7 @@ async function createTestCase() {
 
   // Other peer
 
-  const treeB = new FingerprintTree(concatMonoid, compare);
+  const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
 
   const setB = createTestSet();
 

--- a/src/range_messenger/range_messenger.test.ts
+++ b/src/range_messenger/range_messenger.test.ts
@@ -3,7 +3,7 @@ import { FingerprintTree } from "../fingerprint_tree/fingerprint_tree.ts";
 import { concatMonoid } from "../lifting_monoid.ts";
 import { RangeMessenger } from "./range_messenger.ts";
 import { objConfig } from "./range_messenger_config.ts";
-import { sync } from "../util.ts";
+import { reconcile } from "../util.ts";
 
 function multiplyElements(elements: string[], by: number): string[] {
   const acc = [];
@@ -89,7 +89,7 @@ async function createTestCase() {
     rangeDivision: 2,
   });
 
-  await sync(brokerA, brokerB);
+  await reconcile(brokerA, brokerB);
 
   return {
     setA: Array.from(treeA.lnrValues()),

--- a/src/range_messenger/range_messenger.test.ts
+++ b/src/range_messenger/range_messenger.test.ts
@@ -55,7 +55,7 @@ function nativeEquals(a: string, b: string) {
 }
 
 async function createTestCase() {
-  const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
+  const treeA = new FingerprintTree(concatMonoid, compare);
 
   const setA = createTestSet();
 
@@ -73,7 +73,7 @@ async function createTestCase() {
 
   // Other peer
 
-  const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
+  const treeB = new FingerprintTree(concatMonoid, compare);
 
   const setB = createTestSet();
 

--- a/src/range_messenger/range_messenger.ts
+++ b/src/range_messenger/range_messenger.ts
@@ -373,6 +373,7 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
 
           return acc;
         } else {
+          // Otherwise we subdivide.
           const chunkSize = Math.ceil(size / this.rangeDivision);
           const acc: ProcessStageResult<ValueType, LiftedType>[] = [];
 
@@ -399,6 +400,8 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
           const itemsToUse = items;
           let changedItems = false;
 
+          // LEFT HERE. Need a better way to subdivide ranges where the query loops over.
+
           if (result.lowerBound >= result.upperBound) {
             const indexFirstItemGteLowerBound = items.findIndex((item) => {
               return item >= result.lowerBound;
@@ -408,6 +411,16 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
               const newEnd = itemsToUse.splice(0, indexFirstItemGteLowerBound);
               itemsToUse.push(...newEnd);
               changedItems = true;
+
+              /*
+              console.log(
+                result.lowerBound,
+                result.upperBound,
+                items,
+                itemsToUse,
+                indexFirstItemGteLowerBound,
+              );
+              */
             }
           }
 

--- a/src/range_messenger/range_messenger.ts
+++ b/src/range_messenger/range_messenger.ts
@@ -568,6 +568,10 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
   private checkIsDone(
     message: ProcessStageResult<ValueType, LiftedType>,
   ): void {
+    if (this.isDoneTee.state !== "pending") {
+      return;
+    }
+
     switch (message.type) {
       case "emptySet": {
         if (message.canRespond) {

--- a/src/range_messenger/range_messenger.ts
+++ b/src/range_messenger/range_messenger.ts
@@ -401,11 +401,27 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
           let changedItems = false;
 
           // LEFT HERE. Need a better way to subdivide ranges where the query loops over.
+          // E.g. rang n - f
+          // items would be in proper order: eggs, goat, node,
+          // but if we want to subdivide it's not right, you want node, eggs, goat.
+
+          // Rather than rearrange the items, do the query from the first bit to the max range, and the second bit from the min of the range, and glue them together?
+
+          // But then you need to end up getting a range three times, because we still need the right fingerprint.
+
+          // so we really need to reconstruct this array the way I'm doing.
 
           if (result.lowerBound >= result.upperBound) {
-            const indexFirstItemGteLowerBound = items.findIndex((item) => {
-              return item >= result.lowerBound;
-            });
+            let indexFirstItemGteLowerBound = 0;
+
+            for (let i = 0; i <= items.length; i++) {
+              const item = items[i];
+
+              if (item >= result.lowerBound) {
+                indexFirstItemGteLowerBound = i;
+                break;
+              }
+            }
 
             if (indexFirstItemGteLowerBound > 0) {
               const newEnd = itemsToUse.splice(0, indexFirstItemGteLowerBound);
@@ -675,9 +691,11 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
     // In the sixth stage af the pipeline we encode the messages.
 
     // First decode the incoming messages.
+
     const decoded = this.decode(message);
 
     // Then consolidate successive payload messages into a single message with many items.
+
     const collated = this.collatePayloads(decoded);
 
     if (collated === undefined) {
@@ -690,6 +708,7 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
     const consolidated: ProcessStageResult<ValueType, LiftedType>[] = [];
 
     // Then consolidate adjacent done messages into a single done message.
+
     for (const item of processed) {
       const res = this.consolidateAdjacentDones(item);
 

--- a/src/range_messenger/range_messenger_config.ts
+++ b/src/range_messenger/range_messenger_config.ts
@@ -15,6 +15,16 @@ export type RangeMessengerConfig<EncodedType, ValueType, LiftType> = {
     terminal: () => EncodedType;
   };
   decode: {
+    getType: (
+      message: EncodedType,
+    ) =>
+      | "emptySet"
+      | "lowerBound"
+      | "payload"
+      | "emptyPayload"
+      | "done"
+      | "fingerprint"
+      | "terminal";
     emptySet: (message: EncodedType) => boolean;
     lowerBound: (message: EncodedType) => ValueType;
     payload: (
@@ -97,6 +107,13 @@ export const objConfig: RangeMessengerConfig<
     }),
   },
   decode: {
+    getType: (obj) => {
+      if ("type" in obj === false) {
+        throw "Can't determine type";
+      }
+
+      return obj.type;
+    },
     emptySet: (obj) => {
       if (obj.type === "emptySet") {
         return obj.canRespond;

--- a/src/reconcile.test.ts
+++ b/src/reconcile.test.ts
@@ -24,7 +24,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeA = new FingerprintTree(concatMonoid, compare);
 
     const setA = ["ape", "cat", "eel", "fox"];
 
@@ -42,7 +42,7 @@ Deno.test({
 
     // Other peer
 
-    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
+    const treeB = new FingerprintTree(concatMonoid, compare);
 
     const setB = ["bee", "doe", "eel", "gnu"];
 

--- a/src/reconcile.test.ts
+++ b/src/reconcile.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "https://deno.land/std@0.158.0/testing/asserts.ts";
+import { FingerprintTree } from "./fingerprint_tree/fingerprint_tree.ts";
+import { concatMonoid } from "./lifting_monoid.ts";
+import { RangeMessenger } from "./range_messenger/range_messenger.ts";
+import { objConfig } from "./range_messenger/range_messenger_config.ts";
+import { reconcile } from "./util.ts";
+
+function compare<T>(a: T, b: T) {
+  if (a > b) {
+    return 1;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+function nativeEquals(a: string, b: string) {
+  return a === b;
+}
+
+Deno.test({
+  name: "reconcile",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const treeA = new FingerprintTree(concatMonoid, compare, "" as string);
+
+    const setA = ["ape", "cat", "eel", "fox"];
+
+    for (const item of setA) {
+      treeA.insert(item);
+    }
+
+    const brokerA = new RangeMessenger({
+      tree: treeA,
+      fingerprintEquals: nativeEquals,
+      encoding: objConfig,
+      payloadThreshold: 1,
+      rangeDivision: 2,
+    });
+
+    // Other peer
+
+    const treeB = new FingerprintTree(concatMonoid, compare, "" as string);
+
+    const setB = ["bee", "doe", "eel", "gnu"];
+
+    for (const item of setB) {
+      treeB.insert(item);
+    }
+
+    const brokerB = new RangeMessenger({
+      tree: treeB,
+      fingerprintEquals: nativeEquals,
+      encoding: objConfig,
+      payloadThreshold: 1,
+      rangeDivision: 2,
+    });
+
+    await reconcile(brokerA, brokerB);
+
+    assertEquals(treeA.lnrValues(), treeB.lnrValues());
+  },
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,8 +20,6 @@ export function reconcile<E, V, L>(
       for (const msg of responses) {
         queueA.push(msg);
       }
-
-      console.groupEnd();
     }
   })();
 
@@ -162,69 +160,3 @@ export class FastFIFO<T> {
     }
   }
 }
-
-/** Execute a complete exchange between two RangeMessengers, syncing their trees. */
-/*
-export async function reconcile<E, V, L>(
-  a: RangeMessenger<E, V, L>,
-  b: RangeMessenger<E, V, L>,
-): Promise<unknown[]> {
-  const queueA = new AsyncQueue<E>();
-  const queueB = new AsyncQueue<E>();
-
-  queueB.push(...a.initialMessages());
-
-  (async () => {
-    for await (const msg of queueB) {
-      const responses = b.respond(msg);
-
-      if (responses.length) {
-        queueA.push(...responses);
-      }
-    }
-  })();
-
-  (async () => {
-    for await (const msg of queueA) {
-      const responses = a.respond(msg);
-
-      if (responses.length) {
-        queueB.push(...responses);
-      }
-    }
-  })();
-
-  a.isDone().then(() => queueA.close());
-  b.isDone().then(() => queueB.close());
-
-  return Promise.all([a.isDone(), b.isDone()]);
-}
-*/
-
-/** Execute a complete exchange between two RangeMessengers, syncing their trees. */
-/*
-export async function reconcile<E, V, L>(
-  from: RangeMessenger<E, V, L>,
-  to: RangeMessenger<E, V, L>,
-  round: number = 0,
-  messages?: AsyncIterable<E> | Iterable<E>,
-  isDone?: Deferred<unknown>,
-): Promise<void> {
-  const msgs: E[] = [];
-
-  const messagesToProcess = messages || from.initialMessages();
-
-  for await (
-    const msg of messagesToProcess
-  ) {
-    const responses = to.respond(msg);
-    msgs.push(...responses);
-  }
-
-  if (isDone?.state === "fulfilled") {
-    return Promise.resolve();
-  } else {
-    await reconcile(to, from, round + 1, msgs, to.isDone());
-  }
-}
-*/

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,28 +13,20 @@ export function reconcile<E, V, L>(
 
   (async () => {
     for await (const msg of queueB) {
-      //   console.log("B got", msg);
-
       const responses = b.respond(msg);
 
-      //  await sleep();
-
-      for (const res of responses) {
-        queueA.push(res);
+      if (responses.length) {
+        queueA.push(...responses);
       }
     }
   })();
 
   (async () => {
     for await (const msg of queueA) {
-      //  console.log("A got", msg);
-
       const responses = a.respond(msg);
 
-      // await sleep();
-
-      for (const res of responses) {
-        queueB.push(res);
+      if (responses.length) {
+        queueB.push(...responses);
       }
     }
   })();

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,171 @@
 import { RangeMessenger } from "./range_messenger/range_messenger.ts";
-import { AsyncQueue } from "https://deno.land/x/for_awaitable_queue@1.0.0/mod.ts";
 
 /** Execute a complete exchange between two RangeMessengers, syncing their trees. */
+
 export function reconcile<E, V, L>(
+  a: RangeMessenger<E, V, L>,
+  b: RangeMessenger<E, V, L>,
+): Promise<unknown[]> {
+  const queueA = new FastFIFO<E>(128);
+  const queueB = new FastFIFO<E>(128);
+
+  for (const msg of a.initialMessages()) {
+    queueB.push(msg);
+  }
+
+  (async () => {
+    for await (const msg of queueB) {
+      const responses = b.respond(msg);
+
+      for (const msg of responses) {
+        queueA.push(msg);
+      }
+
+      console.groupEnd();
+    }
+  })();
+
+  (async () => {
+    for await (const msg of queueA) {
+      const responses = a.respond(msg);
+
+      for (const msg of responses) {
+        queueB.push(msg);
+      }
+    }
+  })();
+
+  a.isDone().then(() => queueA.close());
+  b.isDone().then(() => queueB.close());
+
+  return Promise.all([a.isDone(), b.isDone()]);
+}
+
+export const END = Symbol("Stream ended.");
+export const ERROR = Symbol("Stream errored.");
+
+export type Enqueueable<T> = T | Promise<T> | typeof END | typeof ERROR;
+
+export type Resolver<T> = (value: T | PromiseLike<T>) => void;
+
+export type EndOptions = { immediately?: boolean; withError?: Error };
+
+// Adapted from https://github.com/mafintosh/fast-fifo to turn into AsyncIterable
+
+class FixedFIFO<T> {
+  buffer: Array<T | undefined>;
+  private mask: number;
+  private top = 0;
+  private btm = 0;
+
+  next: null | FixedFIFO<T> = null;
+
+  constructor(hwm: number) {
+    if (!(hwm > 0) || ((hwm - 1) & hwm) !== 0) {
+      throw new Error("Max size for a FixedFIFO should be a power of two");
+    }
+    this.buffer = new Array(hwm);
+    this.mask = hwm - 1;
+    this.top = 0;
+    this.btm = 0;
+  }
+
+  push(data: T) {
+    if (this.buffer[this.top] !== undefined) return false;
+    this.buffer[this.top] = data;
+    this.top = (this.top + 1) & this.mask;
+    return true;
+  }
+
+  shift() {
+    const last = this.buffer[this.btm];
+    if (last === undefined) return undefined;
+    this.buffer[this.btm] = undefined;
+    this.btm = (this.btm + 1) & this.mask;
+    return last;
+  }
+
+  peek() {
+    return this.buffer[this.btm];
+  }
+
+  isEmpty() {
+    return this.buffer[this.btm] === undefined;
+  }
+}
+
+export class FastFIFO<T> {
+  private hwm: number;
+  private head: FixedFIFO<Enqueueable<T>>;
+  private tail: FixedFIFO<Enqueueable<T>>;
+  private resolve: null | Resolver<Enqueueable<T>> = null;
+
+  constructor(hwm: number) {
+    this.hwm = hwm || 16;
+    this.head = new FixedFIFO(this.hwm);
+    this.tail = this.head;
+  }
+
+  push(val: Enqueueable<T>) {
+    if (this.resolve) {
+      this.resolve(val);
+      this.resolve = null;
+      return;
+    }
+
+    if (!this.head.push(val)) {
+      const prev = this.head;
+      this.head = prev.next = new FixedFIFO<Enqueueable<T>>(
+        2 * this.head.buffer.length,
+      );
+      this.head.push(val);
+    }
+  }
+
+  shift() {
+    const val = this.tail.shift();
+    if (val === undefined && this.tail.next) {
+      const next = this.tail.next;
+      this.tail.next = null;
+      this.tail = next;
+      return this.tail.shift();
+    }
+    return val;
+  }
+
+  peek() {
+    return this.tail.peek();
+  }
+
+  isEmpty() {
+    return this.head.isEmpty();
+  }
+
+  close() {
+    this.push(END);
+  }
+
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      const shifted = this.shift();
+
+      const value = shifted ||
+        await new Promise<Enqueueable<T>>((res) => {
+          this.resolve = res;
+        });
+
+      if (value === END || value === ERROR) {
+        break;
+      }
+
+      yield value;
+    }
+  }
+}
+
+/** Execute a complete exchange between two RangeMessengers, syncing their trees. */
+/*
+export async function reconcile<E, V, L>(
   a: RangeMessenger<E, V, L>,
   b: RangeMessenger<E, V, L>,
 ): Promise<unknown[]> {
@@ -36,3 +199,32 @@ export function reconcile<E, V, L>(
 
   return Promise.all([a.isDone(), b.isDone()]);
 }
+*/
+
+/** Execute a complete exchange between two RangeMessengers, syncing their trees. */
+/*
+export async function reconcile<E, V, L>(
+  from: RangeMessenger<E, V, L>,
+  to: RangeMessenger<E, V, L>,
+  round: number = 0,
+  messages?: AsyncIterable<E> | Iterable<E>,
+  isDone?: Deferred<unknown>,
+): Promise<void> {
+  const msgs: E[] = [];
+
+  const messagesToProcess = messages || from.initialMessages();
+
+  for await (
+    const msg of messagesToProcess
+  ) {
+    const responses = to.respond(msg);
+    msgs.push(...responses);
+  }
+
+  if (isDone?.state === "fulfilled") {
+    return Promise.resolve();
+  } else {
+    await reconcile(to, from, round + 1, msgs, to.isDone());
+  }
+}
+*/


### PR DESCRIPTION
## FingerprintTree

- Adds a lifting monoid to precalculate the largest child node of a given node
- Cache the trees smallest node upon every insertion for fetching later.

## RangeMessenger

- Add a `getType` method to the messenger config for determining message type
- Use for loop instead of `findIndex` in the `RangeMessenger.process` when rearranging items for subdivision

## Other

- Improve FingerprintTree benchmarking
- Add a measure_respond script for testing / flamegraphing
- Use a FIFO (adapted from https://github.com/mafintosh/fast-fifo) instead of an AsyncQueue when reconciling