### PR TITLE
Fix synthesised label generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+- Fixes a bug which caused value types to be used as fingerprints when
+  calculating fingerprints for certain kinds of ranges.
+
 # 1.0.0
 
 - Added `getType` to `RangeMessengerConfig.decode`

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -445,7 +445,9 @@ export class FingerprintTree<ValueType, LiftedType>
           y,
         );
 
-        const synthesisedLabel = [maxValue as unknown as LiftedType, [1, [
+        const maxLifted = this.monoid.lift(maxValue);
+
+        const synthesisedLabel = [maxLifted[0], [1, [
           [maxValue],
           maxValue,
         ]]] as [
@@ -504,7 +506,8 @@ export class FingerprintTree<ValueType, LiftedType>
           maxValue,
         );
 
-        const synthesisedLabel = [maxValue as unknown as LiftedType, [1, [
+        const maxLifted = this.monoid.lift(maxValue);
+        const synthesisedLabel = [maxLifted[0], [1, [
           [maxValue],
           maxValue,
         ]]] as [

--- a/src/range_messenger/range_messenger.ts
+++ b/src/range_messenger/range_messenger.ts
@@ -192,8 +192,11 @@ export class RangeMessenger<EncodedMessageType, ValueType, LiftedType> {
           return ({ "type": "terminal" });
         }
       }
-    } catch {
+    } catch (err) {
       // argh
+      console.group("range-reconcile: Could not decode message");
+      console.warn(message);
+      console.warn(err);
     }
 
     return null as never;


### PR DESCRIPTION
Fixes a bug which caused value types to be used as fingerprints when calculating fingerprints for certain kinds of ranges.