### PR TITLE
Do not resend values which were just received from the other side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.2
+
+- Improved efficiency of reconciliation by no longer re-sending any payloads
+  which were just received. This reduces the number of messages sent and the
+  overhead needed to process them.
+
 # 1.0.1
 
 - Fixes a bug which caused value types to be used as fingerprints when

--- a/src/fingerprint_tree/fingerprint_tree.ts
+++ b/src/fingerprint_tree/fingerprint_tree.ts
@@ -640,4 +640,8 @@ export class FingerprintTree<ValueType, LiftedType>
     }
     return { label: acc2, nextTree: null };
   }
+
+  isValueEqual(a: ValueType, b: ValueType): boolean {
+    return this.compare(a, b) === 0;
+  }
 }


### PR DESCRIPTION
Fixes an issue where a `RangeMessenger` would send back values its partner already has, as detailed here: https://github.com/adzialocha/range-payload/

Thanks to @adzialocha and @sandreae for finding this!